### PR TITLE
Fixed the sample error message function

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -31,7 +31,7 @@ client.OnClientMethod = func(hub, method string, arguments []json.RawMessage) {
     fmt.Println("METHOD: ", method)
     fmt.Println("ARGUMENTS: ", arguments)
 }
-client.OnErrorMethod = func (err error) {
+client.OnMessageError = func (err error) {
    fmt.Println("ERROR OCCURRED: ", err)
 }
 ----


### PR DESCRIPTION
Changed the function overridden in the example from OnErrorMethod to OnMessageError which is what it is in the client code.